### PR TITLE
feat!: events handling

### DIFF
--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,0 +1,64 @@
+import type { CommandOutput } from '@/types'
+import type { Blop } from '@/structures'
+import type { ChatInputCommandInteraction, InteractionResponse, Message } from 'discord.js'
+
+import { Event } from '@/structures'
+
+/**
+ * @class InteractionCreate
+ */
+export default class InteractionCreate extends Event {
+  /**
+   * @property {CommandOutput} output
+   * @description The output of the command execution.
+   */
+  private output: CommandOutput
+  constructor() {
+    super('interactionCreate')
+
+    this.output = null
+  }
+
+  async handle(client: Blop, interaction: ChatInputCommandInteraction<'cached'>): Promise<void | InteractionResponse | Message> {
+    if (!interaction.isCommand()) return
+
+    try {
+      const command = client.commands.filter((module) => module.name === interaction.commandName)[0]
+
+      if (!command) return
+
+      client.logger.log(`[Shard #${interaction.guild.shardId}] ${interaction.user.tag}(${interaction.user.id}) ran command ${command.name} on ${interaction.guild.name}(${interaction.guild.id}) in #${interaction.channel?.name}(${interaction.channel!.id}).`)
+
+      try {
+        this.output = await command.execute({ client, interaction })
+      } catch (error: any) {
+        client.logger.error(error instanceof Error ? error.stack : error)
+        return interaction.reply('\uD83D\uDEA7 An error occurred. Try again later.')
+      }
+
+      if (interaction.replied) return
+
+      if (this.output && (typeof this.output === 'string' || (typeof this.output === 'object' && (this.output.embeds || this.output.files)))) {
+        const message: {
+          content?: string
+          embeds?: any[]
+          files?: any[]
+          components?: any[]
+        } = {}
+
+        typeof this.output === 'object' ? message.content = this.output.content : null
+        typeof this.output === 'object' ? message.embeds = this.output.embeds : null
+        typeof this.output === 'object' ? message.files = this.output.files : null
+        typeof this.output === 'object' ? message.components = this.output.components : null
+        typeof this.output === 'string' ? message.content = this.output : null
+
+        return interaction.reply(message).catch((error) => {
+          client.logger.error(error)
+          return interaction.followUp('\uD83D\uDEA7 An error occurred. Try again later.')
+        })
+      }
+    } catch (error: any) {
+      return client.logger.error(`[Shard #${interaction.guild.shardId}] ${this.name} - ${error instanceof Error ? error.stack : error}`)
+    }
+  }
+}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,0 +1,36 @@
+import type { Blop } from '@/structures'
+import { Event } from '@/structures'
+
+/**
+ * @class Ready
+ */
+export default class Ready extends Event {
+  constructor() {
+    super('ready', { once: true })
+  }
+
+  /**
+	 * Handles ready
+	 * @param {Blop} client The Discord client instance
+	 * @returns {Promise<void>} Nothing
+	 */
+  handle(client: Blop): void {
+    try {
+      // If the token isn't a bot token the process will be destroyed.
+      if (!client.user.bot) {
+        client.logger.error('An invalid token was provided. (Bot token expected.)')
+        return process.exit(0)
+      }
+
+      client.logger.info(`[Shard #${client.shard!.ids[0]}] Discord Client connected.`)
+
+      client.user.setPresence({
+        activities: [{
+          name: 'with your heart'
+        }]
+      })
+    } catch (error: any) {
+      return client.logger.error(`${this.name} - ${error instanceof Error ? error.stack : error}`)
+    }
+  }
+}

--- a/src/structures/Event.ts
+++ b/src/structures/Event.ts
@@ -23,8 +23,8 @@ export class Event {
    * @param {boolean} options.once - A boolean indicating whether the event should only be handled once.
    */
   constructor(name: string, options: { once?: boolean } = {}) {
-    this.name = name;
-    if (options.once) this.once = options.once;
+    this.name = name
+    if (options.once) this.once = options.once
   }
 
   /**
@@ -35,6 +35,6 @@ export class Event {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   handle(...args: any[]) {
-    throw new Error(`${this.name} doesn't have an handle() method.`);
+    throw new Error(`${this.name} doesn't have an handle() method.`)
   }
 }

--- a/src/structures/Event.ts
+++ b/src/structures/Event.ts
@@ -1,0 +1,40 @@
+/**
+ * @class Event
+ * @description This class represents an event in the application based on Discord bot client events.
+ */
+export class Event {
+  /**
+   * @property {string} name
+   * @description The name of the event.
+   */
+  public readonly name: string
+
+  /**
+   * @property {boolean} once
+   * @description A boolean indicating whether the event should only be handled once.
+   * @default false
+   */
+  public readonly once: boolean = false
+
+  /**
+   * @constructor
+   * @param {string} name - The name of the event.
+   * @param {Object} options - The options for the event.
+   * @param {boolean} options.once - A boolean indicating whether the event should only be handled once.
+   */
+  constructor(name: string, options: { once?: boolean } = {}) {
+    this.name = name;
+    if (options.once) this.once = options.once;
+  }
+
+  /**
+   * @method handle
+   * @description This method should be overridden in subclasses to define what should happen when the event is handled.
+   * @param {...any[]} args - The arguments to pass to the event handler.
+   * @throws {Error} Throws an error if the method is not overridden in a subclass.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  handle(...args: any[]) {
+    throw new Error(`${this.name} doesn't have an handle() method.`);
+  }
+}

--- a/src/structures/index.ts
+++ b/src/structures/index.ts
@@ -1,2 +1,3 @@
 export { Blop } from './Client'
 export { Command } from './Command'
+export { Event } from './Event'

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -49,7 +49,8 @@ export async function loadConfig(
     defaults: {
       maintenance: false,
       dirs: {
-        commands: 'src/commands'
+        commands: 'src/commands',
+        events: 'src/events'
       },
       maintainers: []
     }

--- a/types.d.ts
+++ b/types.d.ts
@@ -9,6 +9,7 @@ import type {
 export interface Config {
   dirs?: {
     commands?: string
+    events?: string
   }
   maintainers?: Snowflake[]
 }


### PR DESCRIPTION
### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Description

<!-- Describe your changes in detail -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR introduces Discord event handling.

Event files must be added to the defined directory (see config).
Event file names must be the same as Discord.js event names (see https://discord.js.org/docs/packages/discord.js/14.15.2/Client:Class for a complete list of events)

Basic events were added, such as the ready event (to set the bot client status once ready), and the interaction create event (to handle command execution)

### Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of the project *(using `pnpm lint` and `pnpm lint --fix`)*
