### PR TITLE
feat: implement command interaction cooldown (rate limit)

### DIFF
--- a/src/structures/Command.ts
+++ b/src/structures/Command.ts
@@ -33,6 +33,13 @@ export class Command {
   public description: (context: CommandContext | PartialCommandContext) => string
 
   /**
+   * The cooldown period for the command in milliseconds.
+   * This property determines the minimum amount of time that must pass
+   * before the command can be executed again.
+   */
+  public cooldown: number
+
+  /**
    * The body of the application command.
    */
   public applicationCommandBody: {
@@ -60,6 +67,8 @@ export class Command {
       options: options.options ?? [],
       dm_permission: false
     }
+
+    this.cooldown = options.cooldown || 2500
   }
 
   /**

--- a/types.d.ts
+++ b/types.d.ts
@@ -20,6 +20,7 @@ export interface CommandOptions {
   category?: string
   description: (context: CommandContext | PartialCommandContext) => string
   options?: APIApplicationCommandOption[]
+  cooldown?: number
 }
 
 export interface CommandContext {


### PR DESCRIPTION
### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Chore (updates to the build process or auxiliary tools and libraries)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Description

<!-- Describe your changes in detail -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This pull request introduces a rate limit feature for command interactions.
- In the Command class, a cooldown property has been added to represent the cooldown period for the command in milliseconds. This determines the minimum amount of time that must pass before the command can be executed again. The default value is set to `2500 milliseconds` if not provided in the command options. 
- In the InteractionCreate event, command cooldown functionality has been implemented. This includes a new 'cooldowns' collection to track user cooldowns, a 'cooldownSweep' interval to clear expired cooldowns, and a 'userInCooldown' method to handle interactions from users currently in cooldown.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of the project *(using `pnpm lint` and `pnpm lint --fix`)*
